### PR TITLE
GitHub Actions: Add more flake8 tests

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -46,10 +46,8 @@ jobs:
 
     - name: Lint with flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # Ideally max-complexity should be set to 10
+        flake8 . --count --ignore=E302,F401,F841,W605 --max-complexity=20 --max-line-length=88 --statistics
 
     - name: Test with pytest (${{ matrix.monty-storage }})
       continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Lint with flake8
       run: |
         # Ideally max-complexity should be set to 10
-        flake8 . --count --ignore=E302,F401,F841,W605 --max-complexity=20 --max-line-length=88 --statistics
+        flake8 . --count --ignore=E302,F401,F841,W503,W504,W605 --max-complexity=26 --max-line-length=88 --statistics
 
     - name: Test with pytest (${{ matrix.monty-storage }})
       continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -5,6 +5,7 @@ name: Python package
 
 on:
   push:
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
Instead of selecting a handful of vital tests to run, let’s run all flake8 tests ignoring only a handful of tests.

flake8 . --ignore=E302,F401,F841,W605