### PR TITLE
uses ast.literal_eval() over eval()

### DIFF
--- a/montydb/types/_nobson.py
+++ b/montydb/types/_nobson.py
@@ -1,7 +1,7 @@
 import sys
 import types
 import base64
-
+import ast
 
 def _mock(name):
     class Mock(object):
@@ -160,7 +160,7 @@ class NoBSON(types.ModuleType):
         for s in _encoder.iterencode(doc):
             if s == _key_sep:
                 if not _encoder.key_is_keyword:
-                    key = eval(candidate)
+                    key = ast.literal_eval(candidate)
                     if not isinstance(key, cls._string_types):
                         raise cls.InvalidDocument(
                             "documents must have only string keys, key was %r" % key

--- a/montydb/types/_nobson.py
+++ b/montydb/types/_nobson.py
@@ -3,6 +3,7 @@ import types
 import base64
 import ast
 
+
 def _mock(name):
     class Mock(object):
         def __init__(self, *args, **kwargs):


### PR DESCRIPTION
static security checking of codebase using Bandit revealed use of unsecure eval() function.

```
>> Issue: [B307:blacklist] Use of possibly insecure function - consider using safer ast.literal_eval.
   Severity: Medium   Confidence: High
   Location: montydb/types/_nobson.py:163
   More Info: https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b307-eval
162                     if not _encoder.key_is_keyword:
163                         key = eval(candidate)
164                         if not isinstance(key, cls._string_types):
```

Have implemented ast.literal_eval() in its place 