### PR TITLE
Update base.py

### DIFF
--- a/montydb/base.py
+++ b/montydb/base.py
@@ -20,9 +20,9 @@
 
 
 from collections import (
-    OrderedDict,
-    MutableMapping,
+    OrderedDict
 )
+from collections.abc import MutableMapping
 from .types import (
     abc,
     iteritems,


### PR DESCRIPTION
MutableMapping should be imported from collections.abc as said in documentation https://docs.python.org/3.9/library/collections.abc.html#collections.abc.MutableMapping

Mainly we need it because its fix #65 (python3.10 compatibility)