### PR TITLE
Allow "$regex" inside "$not" queries on Mongo 4

### DIFF
--- a/montydb/configure.py
+++ b/montydb/configure.py
@@ -310,13 +310,16 @@ def _mongo_compat(version):
         patch(queries, "_is_comparable", "_is_comparable_ver4")
         patch(queries, "_regex_options_check", "_regex_options_")
         patch(queries, "_mod_remainder_not_num", "_mod_remainder_not_num_")
+        patch(queries, "_not_subspec_op_check", "_not_validate_subspec_op_v4")
 
     elif version == "4.2":
         patch(queries, "_is_comparable", "_is_comparable_ver4")
         patch(queries, "_regex_options_check", "_regex_options_v42")
         patch(queries, "_mod_remainder_not_num", "_mod_remainder_not_num_v42")
+        patch(queries, "_not_subspec_op_check", "_not_validate_subspec_op_v4")
 
     else:
         patch(queries, "_is_comparable", "_is_comparable_ver4")
         patch(queries, "_regex_options_check", "_regex_options_")
         patch(queries, "_mod_remainder_not_num", "_mod_remainder_not_num_v42")
+        patch(queries, "_not_subspec_op_check", "_not_validate_subspec_op_v4")

--- a/montydb/engine/queries.py
+++ b/montydb/engine/queries.py
@@ -377,8 +377,7 @@ class QueryFilter(object):
             for op in sub_spec:
                 if op not in self.field_ops:
                     raise OperationFailure("unknown operator: {}".format(op))
-                if op == "$regex":
-                    raise OperationFailure("$not cannot have a regex")
+                _not_subspec_op_check(op)
 
             return self.subparser("$not", sub_spec)
 
@@ -401,6 +400,18 @@ class QueryFilter(object):
 
 def _is_expression_obj(sub_spec):
     return is_duckument_type(sub_spec) and next(iter(sub_spec)).startswith("$")
+
+
+def _not_validate_subspec_op_(op):
+    if op == "$regex":
+        raise OperationFailure("$not cannot have a regex")
+
+
+def _not_validate_subspec_op_v4(sub_spec):
+    pass
+
+
+_not_subspec_op_check = _not_validate_subspec_op_
 
 
 # Only for preserving `int` type flags to bypass

--- a/tests/test_engine/test_queries/test_queryop_logical_not.py
+++ b/tests/test_engine/test_queries/test_queryop_logical_not.py
@@ -1,6 +1,11 @@
 
 import re
+import pytest
 from montydb.types import bson
+
+from pymongo.errors import OperationFailure as MongoOpFail
+from montydb.errors import OperationFailure as MontyOpFail
+
 from ...conftest import skip_if_no_bson
 
 
@@ -72,6 +77,28 @@ def test_qop_not_5(monty_find, mongo_find):
 
     monty_c = monty_find(docs, spec)
     mongo_c = mongo_find(docs, spec)
+
+    assert count_documents(mongo_c, spec) == 1
+    assert count_documents(monty_c, spec) == count_documents(mongo_c, spec)
+    assert next(monty_c) == next(mongo_c)
+
+
+def test_qop_not_6(monty_find, mongo_find, mongo_version):
+    docs = [
+        {"a": "apple"},
+        {"a": "banana"},
+    ]
+    spec = {"a": {"$not": {"$regex": "^a"}}}
+
+    monty_c = monty_find(docs, spec)
+    mongo_c = mongo_find(docs, spec)
+
+    if mongo_version[0] == 3:
+        with pytest.raises(MongoOpFail):
+            next(mongo_c)
+        with pytest.raises(MontyOpFail):
+            next(monty_c)
+        return
 
     assert count_documents(mongo_c, spec) == 1
     assert count_documents(monty_c, spec) == count_documents(mongo_c, spec)


### PR DESCRIPTION
Fix for https://github.com/davidlatwe/montydb/issues/81

Mongo 4.* now allows "$regex" inside "$not" queries:

```
 {"$not": {"$regex": "(?i)Hello World"}}
```

This patch modifies the behavior so that it's allowed in Mongo 4.* but not in Mongo 3.*