### PR TITLE
Python 3.7 has been removed from GitHub Actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,15 +20,7 @@ jobs:
         experimental: [ false ]
         monty-storage: [ memory, flatfile, sqlite ]
         mongodb-version: [ "3.6", "4.0", "4.2" ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
-
-        include:
-          # run lmdb tests as experimental due to the seg fault in GitHub
-          #  action is not reproducible on my Windows and Mac.
-          - experimental: true
-            monty-storage: lightning
-            mongodb-version: "4.0"
-            python-version: "3.7"
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
* actions/setup-python#962

# Remove Python 3.7 and add Python 3.13.