### PR TITLE
Remove the dependency on `abatilo/actions-poetry`

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,18 +20,11 @@ jobs:
         experimental: [ false ]
         monty-storage: [ memory, flatfile, sqlite ]
         mongodb-version: [ "3.6", "4.0", "4.2" ]
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11", "3.12" ]
-
-        include:
-          # run lmdb tests as experimental due to the seg fault in GitHub
-          #  action is not reproducible on my Windows and Mac.
-          - experimental: true
-            monty-storage: lightning
-            mongodb-version: "4.0"
-            python-version: "3.7"
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
 
     steps:
     - uses: actions/checkout@v4
+    - run: pipx install poetry==1.3
 
     - name: Set up MongoDB ${{ matrix.mongodb-version }}
       uses: supercharge/mongodb-github-action@1.11.0
@@ -42,11 +35,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-
-    - name: Setup Poetry 1.3
-      uses: abatilo/actions-poetry@v3
-      with:
-        poetry-version: "1.3"
+        cache: "poetry"
 
     - name: Install dependencies via poetry
       run: make install

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,3 +1,0 @@
-# See https://github.com/abatilo/actions-poetry to understand this file.
-virtualenvs.create = true
-virtualenvs.in-project = true

--- a/poetry.toml
+++ b/poetry.toml
@@ -1,2 +1,3 @@
-virtualenvs.in-project=true
+# See https://github.com/abatilo/actions-poetry to understand this file.
 virtualenvs.create = true
+virtualenvs.in-project = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,46 +1,46 @@
+[build-system]
+build-backend = "poetry.core.masonry.api"
+requires = [ "poetry-core>=1" ]
+
 [tool.poetry]
 name = "montydb"
 version = "99.dev.0"
 description = "Monty, Mongo tinified. MongoDB implemented in Python !"
-authors = ["davidlatwe <davidlatwe@gmail.com>"]
+authors = [ "davidlatwe <davidlatwe@gmail.com>" ]
 license = "BSD-3-Clause License"
 readme = "README.md"
 repository = "https://github.com/davidlatwe/montydb"
-keywords = ["monty", "montydb", "pymongo", "mongodb", "database", "embedded"]
+keywords = [ "monty", "montydb", "pymongo", "mongodb", "database", "embedded" ]
 classifiers = [
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Topic :: Database",
-    "Topic :: Database :: Database Engines/Servers",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: BSD License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3.7",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Database",
+  "Topic :: Database :: Database Engines/Servers",
 ]
 
-include=[
-    "LICENSE",
+include = [
+  "LICENSE",
 ]
 
 [tool.poetry.dependencies]
 python = ">=3.7"
 
 [tool.poetry.dev-dependencies]
-toml = "*"
-pytest = "*"
-pytest-cov = "*"
-pymongo = "=3.11.3"
+bandit = "^1"
+black = { version = "*", python = ">=3.6.2", allow-prereleases = true }
+codespell = "^2"
+flake8 = "^5"
 lmdb = { git = "https://github.com/Bye-lemon/py-lmdb.git", rev = "2141c16" }
 mongoengine = "*"
-flake8 = "^5"
-codespell = "^2"
-black = {version = "*", python =">=3.6.2", allow-prereleases = true}
-bandit = "^1"
-
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+pymongo = "=3.11.3"
+pytest = "*"
+pytest-cov = "*"
+toml = "*"


### PR DESCRIPTION
Includes the changes from:
* #101 
* #102 
* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#caching-packages

Now that GitHub Actions now include `pipx` it is much easier to install and use Poetry without overhead.