### PR TITLE
Fix incorrect path conflict check in updator

### DIFF
--- a/montydb/engine/update.py
+++ b/montydb/engine/update.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from ..errors import WriteError
 
-from .field_walker import FieldWalker, FieldWriteError
+from .field_walker import FieldWalker, FieldWriteError, is_conflict
 from .weighted import Weighted, _cmp_decimal
 from .queries import QueryFilter, ordering
 from ..types import (
@@ -164,7 +164,7 @@ class Updator(object):
 
     def check_conflict(self, field):
         for staged in self.fields_to_update:
-            if field.startswith(staged) or staged.startswith(field):
+            if is_conflict(field, staged):
                 msg = (
                     "Updating the path {0!r} would create a "
                     "conflict at {1!r}".format(field, staged[: len(field)])
@@ -318,7 +318,7 @@ def parse_rename(field, new_field, array_filters):
         )
         raise WriteError(msg, code=2)
 
-    if field.startswith(new_field) or new_field.startswith(field):
+    if is_conflict(new_field, field):
         msg = (
             "The source and target field for $rename must not be on the "
             "same path: {0}: {1!r}".format(field, new_field)

--- a/tests/test_engine/test_update/test_update_upsert.py
+++ b/tests/test_engine/test_update/test_update_upsert.py
@@ -43,3 +43,15 @@ def test_upsert_3(monty_update, mongo_update):
     assert mongo_c[1] == monty_c[1]
     monty_c.rewind()
     assert monty_c[1] == {"b": 9}
+
+
+def test_upsert_4(monty_update, mongo_update):
+    docs = []
+
+    find = {"x": 1}
+    spec = {"$set": {"a": 1, "ab": 2}}
+
+    monty_c = monty_update(docs, spec, find, upsert=True)
+    mongo_c = mongo_update(docs, spec, find, upsert=True)
+
+    assert list(mongo_c) == list(monty_c)

--- a/tests/test_engine/test_update/test_update_upsert.py
+++ b/tests/test_engine/test_update/test_update_upsert.py
@@ -54,4 +54,6 @@ def test_upsert_4(monty_update, mongo_update):
     monty_c = monty_update(docs, spec, find, upsert=True)
     mongo_c = mongo_update(docs, spec, find, upsert=True)
 
-    assert list(mongo_c) == list(monty_c)
+    assert mongo_c[0] == monty_c[0]
+    monty_c.rewind()
+    assert monty_c[0] == {"a": 1, "ab": 2, "x": 1}


### PR DESCRIPTION
This PR applies the existing is_conflict logic from FieldWalker to the update function, fixing #109 .