### PR TITLE
Allow multiple filters when updating positional path

### DIFF
--- a/montydb/engine/field_walker.py
+++ b/montydb/engine/field_walker.py
@@ -847,7 +847,6 @@ class FieldWalker(object):
         else:
             return
 
-
     def has_matched(self):
         return any(node.in_array for node in self.matched.values())
 

--- a/montydb/engine/field_walker.py
+++ b/montydb/engine/field_walker.py
@@ -834,18 +834,19 @@ class FieldWalker(object):
         for path, node in self.matched.items():
             if position_path is None or path.startswith(position_path + "."):
                 matched = node
-                break
+
+                first = None
+                while matched.parent is not None:
+                    if not matched.in_array:
+                        break
+                    first = matched
+                    matched = matched.parent
+
+                if first is not None:
+                    return first
         else:
             return
 
-        first = None
-        while matched.parent is not None:
-            if not matched.in_array:
-                break
-            first = matched
-            matched = matched.parent
-
-        return first
 
     def has_matched(self):
         return any(node.in_array for node in self.matched.values())

--- a/tests/test_engine/test_update/test_update.py
+++ b/tests/test_engine/test_update/test_update.py
@@ -401,7 +401,12 @@ def test_update_positional_3(monty_update, mongo_update):
     mongo_c = mongo_update(docs, spec, find)
     monty_c = monty_update(docs, spec, find)
 
-    assert list(mongo_c) == list(monty_c)
+    assert next(mongo_c) == next(monty_c)
+    monty_c.rewind()
+    assert next(monty_c) == {
+        "a": 1,
+        "b": [{"c": 1, "d": 10}]
+    }
 
 
 def test_update_array_faild_1(monty_update, mongo_update):

--- a/tests/test_engine/test_update/test_update.py
+++ b/tests/test_engine/test_update/test_update.py
@@ -394,7 +394,7 @@ def test_update_positional_without_query_condition(monty_update, mongo_update):
 
 
 def test_update_positional_3(monty_update, mongo_update):
-    docs = [{"a": 1, "b": [{"c": 1, "d": 2 }]}]
+    docs = [{"a": 1, "b": [{"c": 1, "d": 2}]}]
     spec = {"$set": {"b.$.d": 10}}
     find = {"a": 1, "b.c": 1}
 

--- a/tests/test_engine/test_update/test_update.py
+++ b/tests/test_engine/test_update/test_update.py
@@ -393,6 +393,17 @@ def test_update_positional_without_query_condition(monty_update, mongo_update):
     # assert mongo_err.value.code == monty_err.value.code
 
 
+def test_update_positional_3(monty_update, mongo_update):
+    docs = [{"a": 1, "b": [{"c": 1, "d": 2 }]}]
+    spec = {"$set": {"b.$.d": 10}}
+    find = {"a": 1, "b.c": 1}
+
+    mongo_c = mongo_update(docs, spec, find)
+    monty_c = monty_update(docs, spec, find)
+
+    assert list(mongo_c) == list(monty_c)
+
+
 def test_update_array_faild_1(monty_update, mongo_update):
     docs = [
         {"a": [{"1": 4}]}


### PR DESCRIPTION
This PR fixes a bug where, if multiple filters are passed, only the first one is checked to determine the index for `$` positional updates.