### PR TITLE
Add find_one_and_update

### DIFF
--- a/montydb/collection.py
+++ b/montydb/collection.py
@@ -488,19 +488,12 @@ class MontyCollection(BaseObject):
                 # during the upsert.
                 upserted_id = raw_result.get("upserted")
                 if upserted_id:
-                    # do not use the projection in find_one to use the
-                    # original queryfilter
-                    new_doc = self.find_one({"_id": upserted_id})
-                    if projection:
-                        queryfilter = QueryFilter(filter)
-                        projector = Projector(projection, queryfilter)
-                        new_fw = FieldWalker(new_doc)
-                        projector(new_fw)
-                        return new_fw.doc
-                    return new_doc
-                return None
-            else:
-                return None
+                    return self.find_one(
+                        {"_id": upserted_id},
+                        projection=projection
+                    )
+
+            return None
         else:
             fw = FieldWalker(doc_to_update)
 

--- a/montydb/collection.py
+++ b/montydb/collection.py
@@ -428,26 +428,28 @@ class MontyCollection(BaseObject):
         **kwargs
     ):
         """
-        Find a single document and update it, returning either the original or updated document.
-        
+        Find a single document and update it, returning either the original 
+        or updated document.
+
         Arguments:
             filter: A query that matches the document to update.
             update: The update operations to apply.
-            projection: A list of field names that should be returned in the result document
-                or a mapping specifying the fields to include or exclude.
-            sort: A list of (key, direction) pairs specifying the sort order for the query.
-            return_document: If False (the default), returns the original document 
-                before it was updated. If True, returns the updated or inserted document.
-                A boolean to match the original ReturnDocument in pymongo.
-            upsert: When True, inserts a new document if no document matches the query. 
+            projection: A list of field names that should be returned in the result
+                document or a mapping specifying the fields to include or exclude.
+            sort: A list of (key, direction) pairs specifying the sort order for the
+                query.
+            return_document: If False (the default), returns the original document
+                before it was updated. If True, returns the updated or inserted
+                document. A boolean to match the original ReturnDocument in pymongo.
+            upsert: When True, inserts a new document if no document matches the query.
                 Defaults to False.
-            bypass_document_validation: If True, allows the write to opt-out of document 
-                level validation. Not implemented.
-            array_filters: A list of filters specifying which array elements an update 
+            bypass_document_validation: If True, allows the write to opt-out of
+                document level validation. Not implemented.
+            array_filters: A list of filters specifying which array elements an update
                 should apply.
             
         Returns:
-            The matching document, before or after the update, or None if no document 
+            The matching document, before or after the update, or None if no document
             matches the filter.
         """
         validate_ok_for_update(update)
@@ -455,10 +457,10 @@ class MontyCollection(BaseObject):
         validate_boolean("upsert", upsert)
         validate_boolean("return_document", return_document)
         # filter is validated in MontyCursor
-        
+
         if bypass_document_validation:
             pass
-            
+
         updator = Updator(update, array_filters)
         self._no_id_update(updator, filter)
 
@@ -479,14 +481,15 @@ class MontyCollection(BaseObject):
                 # Return None as the document did not exist.
                 if not return_document:
                     return None
-                
+
                 # Retrieve the document from the generated id.
                 # Recreating the document from doc_to_update may be complicated
                 # as it also needs to consider filtering fields that are added
                 # during the upsert.
                 upserted_id = raw_result.get("upserted")
                 if upserted_id:
-                    # do not use the projection in find_one to use the original queryfilter
+                    # do not use the projection in find_one to use the
+                    # original queryfilter
                     new_doc = self.find_one({"_id": upserted_id})
                     if projection:
                         queryfilter = QueryFilter(filter)

--- a/montydb/collection.py
+++ b/montydb/collection.py
@@ -16,6 +16,7 @@ from .engine.field_walker import FieldWalker
 from .engine.weighted import Weighted
 from .engine.queries import QueryFilter
 from .engine.update import Updator
+from .engine.project import Projector
 from .types import (
     abc,
     bson,
@@ -47,7 +48,6 @@ NotImplementeds = {
     "find_raw_batches",
     "find_one_and_delete",
     "find_one_and_replace",
-    "find_one_and_update",
     "create_indexes",
     "drop_index",
     "drop_indexes",
@@ -414,6 +414,119 @@ class MontyCollection(BaseObject):
         storage.delete_many(self, doc_ids)
 
         return DeleteResult(raw_result)
+
+    def find_one_and_update(
+        self,
+        filter,
+        update,
+        projection=None,
+        sort=None,
+        return_document=False,
+        upsert=False,
+        bypass_document_validation=False,
+        array_filters=None,
+        **kwargs
+    ):
+        """
+        Find a single document and update it, returning either the original or updated document.
+        
+        Arguments:
+            filter: A query that matches the document to update.
+            update: The update operations to apply.
+            projection: A list of field names that should be returned in the result document
+                or a mapping specifying the fields to include or exclude.
+            sort: A list of (key, direction) pairs specifying the sort order for the query.
+            return_document: If False (the default), returns the original document 
+                before it was updated. If True, returns the updated or inserted document.
+                A boolean to match the original ReturnDocument in pymongo.
+            upsert: When True, inserts a new document if no document matches the query. 
+                Defaults to False.
+            bypass_document_validation: If True, allows the write to opt-out of document 
+                level validation. Not implemented.
+            array_filters: A list of filters specifying which array elements an update 
+                should apply.
+            
+        Returns:
+            The matching document, before or after the update, or None if no document 
+            matches the filter.
+        """
+        validate_ok_for_update(update)
+        validate_list_or_none("array_filters", array_filters)
+        validate_boolean("upsert", upsert)
+        validate_boolean("return_document", return_document)
+        # filter is validated in MontyCursor
+        
+        if bypass_document_validation:
+            pass
+            
+        updator = Updator(update, array_filters)
+        self._no_id_update(updator, filter)
+
+        # find the document to modify
+        cursor = MontyCursor(self, filter=filter, sort=sort, limit=1, **kwargs)
+        doc_to_update = None
+        for doc in cursor:
+            doc_to_update = doc
+            break
+
+        if doc_to_update is None:
+            if upsert:
+                # Create the document
+                raw_result = {"n": 0, "nModified": 0}
+                self._internal_upsert(filter, updator, raw_result)
+
+                # "not return_document" -> BEFORE
+                # Return None as the document did not exist.
+                if not return_document:
+                    return None
+                
+                # Retrieve the document from the generated id.
+                # Recreating the document from doc_to_update may be complicated
+                # as it also needs to consider filtering fields that are added
+                # during the upsert.
+                upserted_id = raw_result.get("upserted")
+                if upserted_id:
+                    # do not use the projection in find_one to use the original queryfilter
+                    new_doc = self.find_one({"_id": upserted_id})
+                    if projection:
+                        queryfilter = QueryFilter(filter)
+                        projector = Projector(projection, queryfilter)
+                        new_fw = FieldWalker(new_doc)
+                        projector(new_fw)
+                        return new_fw.doc
+                    return new_doc
+                return None
+            else:
+                return None
+        else:
+            fw = FieldWalker(doc_to_update)
+
+            # if not an upsert, validate that the _id is not modified.
+            self._no_id_update(updator)
+            if updator(fw):
+                self._storage.update_one(self, fw.doc)
+
+            if projection:
+                # Apply the projection to the original or new document
+                # No need to query the document here.
+                queryfilter = QueryFilter(filter)
+                projector = Projector(projection, queryfilter)
+
+                if not return_document:
+                    # The updator does not alter the original document.
+                    # doc_to_update can be filtered and returned.
+                    original_fw = FieldWalker(doc_to_update)
+                    projector(original_fw)
+                    return original_fw.doc
+                else:
+                    updated_fw = FieldWalker(fw.doc)
+                    projector(updated_fw)
+                    return updated_fw.doc
+            else:
+                if not return_document:
+                    return doc_to_update
+                else:
+                    return fw.doc
 
     def find(self, *args, **kwargs):
         # return a cursor

--- a/montydb/collection.py
+++ b/montydb/collection.py
@@ -428,7 +428,7 @@ class MontyCollection(BaseObject):
         **kwargs
     ):
         """
-        Find a single document and update it, returning either the original 
+        Find a single document and update it, returning either the original
         or updated document.
 
         Arguments:
@@ -447,7 +447,7 @@ class MontyCollection(BaseObject):
                 document level validation. Not implemented.
             array_filters: A list of filters specifying which array elements an update
                 should apply.
-            
+
         Returns:
             The matching document, before or after the update, or None if no document
             matches the filter.

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -385,7 +385,7 @@ def test_find_one_and_update_empty_collection(monty_collection, mongo_collection
 
 
 def test_find_one_and_update_projection_before_update(
-    monty_collection, 
+    monty_collection,
     mongo_collection
 ):
     doc = {

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -337,7 +337,7 @@ def test_find_one_and_update_upsert_no_match(monty_collection, mongo_collection)
     assert "_id" in monty_result
 
     assert monty_collection.count_documents({"a": "X"}) == 1
-    
+
     # Compare with MongoDB result excluding _id
     monty_no_id = {k: v for k, v in monty_result.items() if k != "_id"}
     mongo_no_id = {k: v for k, v in mongo_result.items() if k != "_id"}
@@ -384,7 +384,10 @@ def test_find_one_and_update_empty_collection(monty_collection, mongo_collection
     assert monty_result == mongo_result
 
 
-def test_find_one_and_update_projection_before_update(monty_collection, mongo_collection):
+def test_find_one_and_update_projection_before_update(
+    monty_collection, 
+    mongo_collection
+):
     doc = {
         "_id": 1,
         "a": "X",

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -9,6 +9,7 @@ from pymongo.errors import (
     DuplicateKeyError as mongo_dup_key_err,
     BulkWriteError as mongo_bulkw_err,
 )
+from pymongo import ReturnDocument
 from montydb.errors import (
     DuplicateKeyError as monty_dup_key_err,
     BulkWriteError as monty_bulkw_err,
@@ -188,3 +189,229 @@ def test_collection_count_documents(monty_collection, mongo_collection):
     mongo_res = mongo_collection.count_documents({"a": 1})
 
     assert monty_res == mongo_res
+
+
+def test_find_one_and_update_basic(monty_collection, mongo_collection):
+    doc = {"_id": 1, "a": 10}
+    monty_collection.insert_one(doc.copy())
+    mongo_collection.insert_one(doc.copy())
+
+    monty_result = monty_collection.find_one_and_update(
+        {"_id": 1},
+        {"$set": {"a": 20}},
+        return_document=False
+    )
+
+    mongo_result = mongo_collection.find_one_and_update(
+        {"_id": 1},
+        {"$set": {"a": 20}},
+        return_document=ReturnDocument.BEFORE
+    )
+
+    assert monty_result["a"] == 10
+    assert monty_collection.find_one({"_id": 1})["a"] == 20
+
+    assert monty_result == mongo_result
+
+
+def test_find_one_and_update_return_after(monty_collection, mongo_collection):
+    doc = {"_id": 1, "a": 10}
+    monty_collection.insert_one(doc.copy())
+    mongo_collection.insert_one(doc.copy())
+
+    monty_result = monty_collection.find_one_and_update(
+        {"_id": 1},
+        {"$inc": {"a": 5}},
+        return_document=True
+    )
+
+    mongo_result = mongo_collection.find_one_and_update(
+        {"_id": 1},
+        {"$inc": {"a": 5}},
+        return_document=ReturnDocument.AFTER
+    )
+
+    assert monty_result["a"] == 15
+    assert monty_collection.find_one({"_id": 1})["a"] == 15
+
+    assert monty_result == mongo_result
+
+
+def test_find_one_and_update_with_sort(monty_collection, mongo_collection):
+    docs = [
+        {"_id": 1, "priority": 3, "a": 10},
+        {"_id": 2, "priority": 1, "a": 10},
+        {"_id": 3, "priority": 2, "a": 10}
+    ]
+    for doc in docs:
+        monty_collection.insert_one(doc.copy())
+        mongo_collection.insert_one(doc.copy())
+
+    # Update document based on sorting priority
+    monty_result = monty_collection.find_one_and_update(
+        {"a": 10},
+        {"$set": {"a": 20}},
+        sort=[("priority", 1)],
+        return_document=True
+    )
+
+    mongo_result = mongo_collection.find_one_and_update(
+        {"a": 10},
+        {"$set": {"a": 20}},
+        sort=[("priority", 1)],
+        return_document=ReturnDocument.AFTER
+    )
+
+    assert monty_result["_id"] == 2
+    assert monty_result["a"] == 20
+    assert monty_collection.count_documents({"a": 20}) == 1
+
+    assert monty_result == mongo_result
+
+
+def test_find_one_and_update_with_projection(monty_collection, mongo_collection):
+    doc = {"_id": 1, "a": "X", "b": 30, "c": "Y"}
+    monty_collection.insert_one(doc.copy())
+    mongo_collection.insert_one(doc.copy())
+
+    monty_result = monty_collection.find_one_and_update(
+        {"_id": 1},
+        {"$set": {"b": 31}},
+        projection={"a": 1, "b": 1, "_id": 0},
+        return_document=True
+    )
+
+    mongo_result = mongo_collection.find_one_and_update(
+        {"_id": 1},
+        {"$set": {"b": 31}},
+        projection={"a": 1, "b": 1, "_id": 0},
+        return_document=ReturnDocument.AFTER
+    )
+
+    assert monty_result == {"a": "X", "b": 31}
+    assert "city" not in monty_result
+
+    assert monty_result == mongo_result
+
+
+def test_find_one_and_update_no_match(monty_collection, mongo_collection):
+    doc = {"_id": 1, "a": 10}
+    monty_collection.insert_one(doc.copy())
+    mongo_collection.insert_one(doc.copy())
+
+    monty_result = monty_collection.find_one_and_update(
+        {"_id": 999},
+        {"$set": {"a": 20}},
+        return_document=False
+    )
+
+    mongo_result = mongo_collection.find_one_and_update(
+        {"_id": 999},
+        {"$set": {"a": 20}},
+        return_document=ReturnDocument.BEFORE
+    )
+
+    assert monty_result is None
+    assert monty_collection.find_one({"_id": 1})["a"] == 10
+
+    assert monty_result == mongo_result
+
+
+def test_find_one_and_update_upsert_no_match(monty_collection, mongo_collection):
+    monty_result = monty_collection.find_one_and_update(
+        {"a": "X"},
+        {"$set": {"b": 25}},
+        upsert=True,
+        return_document=True
+    )
+
+    mongo_result = mongo_collection.find_one_and_update(
+        {"a": "X"},
+        {"$set": {"b": 25}},
+        upsert=True,
+        return_document=ReturnDocument.AFTER
+    )
+
+    assert monty_result["a"] == "X"
+    assert monty_result["b"] == 25
+    assert "_id" in monty_result
+
+    assert monty_collection.count_documents({"a": "X"}) == 1
+    
+    # Compare with MongoDB result excluding _id
+    monty_no_id = {k: v for k, v in monty_result.items() if k != "_id"}
+    mongo_no_id = {k: v for k, v in mongo_result.items() if k != "_id"}
+    assert monty_no_id == mongo_no_id
+
+
+def test_find_one_and_update_upsert_return_before(monty_collection, mongo_collection):
+    monty_result = monty_collection.find_one_and_update(
+        {"a": "Y"},
+        {"$set": {"b": 35}},
+        upsert=True,
+        return_document=False
+    )
+
+    mongo_result = mongo_collection.find_one_and_update(
+        {"a": "Y"},
+        {"$set": {"b": 35}},
+        upsert=True,
+        return_document=ReturnDocument.BEFORE
+    )
+
+    assert monty_result is None
+    assert monty_collection.find_one({"a": "Y"})["b"] == 35
+
+    assert monty_result == mongo_result
+
+
+def test_find_one_and_update_empty_collection(monty_collection, mongo_collection):
+    monty_result = monty_collection.find_one_and_update(
+        {},
+        {"$set": {"a": 1}},
+        return_document=False
+    )
+
+    mongo_result = mongo_collection.find_one_and_update(
+        {},
+        {"$set": {"a": 1}},
+        return_document=ReturnDocument.BEFORE
+    )
+
+    assert monty_result is None
+    assert monty_collection.count_documents({}) == 0
+
+    assert monty_result == mongo_result
+
+
+def test_find_one_and_update_projection_before_update(monty_collection, mongo_collection):
+    doc = {
+        "_id": 1,
+        "a": "X",
+        "b": 1,
+        "c": "AA"
+    }
+    monty_collection.insert_one(doc.copy())
+    mongo_collection.insert_one(doc.copy())
+
+    monty_result = monty_collection.find_one_and_update(
+        {"_id": 1},
+        {"$set": {"b": 20, "c": "BB"}},
+        projection={"a": 1, "b": 1, "_id": 0},
+        return_document=False
+    )
+
+    mongo_result = mongo_collection.find_one_and_update(
+        {"_id": 1},
+        {"$set": {"b": 20, "c": "BB"}},
+        projection={"a": 1, "b": 1, "_id": 0},
+        return_document=ReturnDocument.BEFORE
+    )
+
+    assert monty_result == {"a": "X", "b": 1}
+    # Verify update was applied
+    doc = monty_collection.find_one({"_id": 1})
+    assert doc["b"] == 20
+    assert doc["c"] == "BB"
+
+    assert monty_result == mongo_result


### PR DESCRIPTION
Following up on #90 I have tried to implement the `find_one_and_update` method for the collection.

I hope I have understood the logic of the objects correctly and that this follows the usual conventions.

For the docstrings I have used the current pymongo documentation.

For the tests I have compared with the MongoDB version that I have installed locally (6.0), I expect the simple options used here should still be valid for older versions.

One doubt that I have concerns this part:
https://github.com/gpetretto/montydb/blob/111777ca837d5c192a5a57aa57bc5dac8ba419c2/montydb/collection.py#L490-L496
I am not sure I understood correctly the effect of passing the real `queryfilter` to the Projector.
Would it be correct to replace this with
```python
return self.find_one({"_id": upserted_id}, projection=projection)
```
?