### PR TITLE
fix: Do not ignore ruff rules E741 and F841

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,6 @@ dev = [
 line-length = 88
 exclude = [ ".venv", "venv" ]
 
-[tool.ruff.lint]
-ignore = [ "E741", "F841" ]
-
 [tool.codespell]
 skip = ".venv,venv,.git"
 # MongoDB query operator: $nin

--- a/tests/test_collection.py
+++ b/tests/test_collection.py
@@ -117,10 +117,10 @@ def test_collection_insert_one_has_duplicate_key(monty_collection, mongo_collect
     mongo_collection.insert_one(doc)
     monty_collection.insert_one(doc)
 
-    with pytest.raises(mongo_dup_key_err) as mongo_err:
+    with pytest.raises(mongo_dup_key_err):
         mongo_collection.insert_one(doc)
 
-    with pytest.raises(monty_dup_key_err) as monty_err:
+    with pytest.raises(monty_dup_key_err):
         monty_collection.insert_one(doc)
 
     # ignore comparing error code

--- a/tests/test_engine/test_projection/test_projection_elemMatch.py
+++ b/tests/test_engine/test_projection/test_projection_elemMatch.py
@@ -16,10 +16,10 @@ def test_projection_elemMatch_unsupported_option(monty_proj, mongo_proj):
     spec = {}
     proj = {"x": {"a": {"$elemMatch": {"b": 3}}}}
 
-    with pytest.raises(mongo_op_fail) as mongo_err:
+    with pytest.raises(mongo_op_fail):
         next(mongo_proj(docs, spec, proj))
 
-    with pytest.raises(monty_op_fail) as monty_err:
+    with pytest.raises(monty_op_fail):
         next(monty_proj(docs, spec, proj))
 
     # ignore comparing error code
@@ -33,10 +33,10 @@ def test_projection_elemMatch_nested_field(monty_proj, mongo_proj):
     spec = {}
     proj = {"x.a": {"$elemMatch": {"b": 3}}}
 
-    with pytest.raises(mongo_op_fail) as mongo_err:
+    with pytest.raises(mongo_op_fail):
         next(mongo_proj(docs, spec, proj))
 
-    with pytest.raises(monty_op_fail) as monty_err:
+    with pytest.raises(monty_op_fail):
         next(monty_proj(docs, spec, proj))
 
     # ignore comparing error code
@@ -123,10 +123,10 @@ def test_projection_elemMatch_mix_with_slice_1(monty_proj, mongo_proj):
     spec = {}
     proj = {"a": {"$elemMatch": {"$eq": 2}, "$slice": [1, 4]}}
 
-    with pytest.raises(mongo_op_fail) as mongo_err:
+    with pytest.raises(mongo_op_fail):
         next(mongo_proj(docs, spec, proj))
 
-    with pytest.raises(monty_op_fail) as monty_err:
+    with pytest.raises(monty_op_fail):
         next(monty_proj(docs, spec, proj))
 
     # ignore comparing error code

--- a/tests/test_engine/test_projection/test_projection_positional.py
+++ b/tests/test_engine/test_projection/test_projection_positional.py
@@ -343,10 +343,10 @@ def test_projection_positional_err_2(monty_proj, mongo_proj):
     spec = {"b.0.b": 2}
     proj = {"a.b.$": 1}
 
-    with pytest.raises(mongo_op_fail) as mongo_err:
+    with pytest.raises(mongo_op_fail):
         next(mongo_proj(docs, spec, proj))
 
-    with pytest.raises(monty_op_fail) as monty_err:
+    with pytest.raises(monty_op_fail):
         next(monty_proj(docs, spec, proj))
 
     # ignore comparing error code\n# # ignore comparing error code
@@ -360,10 +360,10 @@ def test_projection_positional_err_96_1(monty_proj, mongo_proj):
     spec = {"a.0.b": 2}
     proj = {"a.b.$": 1}
 
-    with pytest.raises(mongo_op_fail) as mongo_err:
+    with pytest.raises(mongo_op_fail):
         next(mongo_proj(docs, spec, proj))
 
-    with pytest.raises(monty_op_fail) as monty_err:
+    with pytest.raises(monty_op_fail):
         next(monty_proj(docs, spec, proj))
 
     # ignore comparing error code
@@ -377,10 +377,10 @@ def test_projection_positional_err_96_2(monty_proj, mongo_proj):
     spec = {"a.0.b": 2}
     proj = {"a.$": 1}
 
-    with pytest.raises(mongo_op_fail) as mongo_err:
+    with pytest.raises(mongo_op_fail):
         next(mongo_proj(docs, spec, proj))
 
-    with pytest.raises(monty_op_fail) as monty_err:
+    with pytest.raises(monty_op_fail):
         next(monty_proj(docs, spec, proj))
 
     # ignore comparing error code
@@ -394,10 +394,10 @@ def test_projection_positional_err_96_3(monty_proj, mongo_proj):
     spec = {"a.1": 1}
     proj = {"a.$": 1}
 
-    with pytest.raises(mongo_op_fail) as mongo_err:
+    with pytest.raises(mongo_op_fail):
         next(mongo_proj(docs, spec, proj))
 
-    with pytest.raises(monty_op_fail) as monty_err:
+    with pytest.raises(monty_op_fail):
         next(monty_proj(docs, spec, proj))
 
     # ignore comparing error code

--- a/tests/test_engine/test_sorting.py
+++ b/tests/test_engine/test_sorting.py
@@ -393,11 +393,11 @@ def test_sort_21(monty_sort, mongo_sort):
     ]
     sort = [("a", 3)]
 
-    with pytest.raises(mongo_op_err) as mongo_err:
+    with pytest.raises(mongo_op_err):
         mongo_c = mongo_sort(docs, sort)
         next(mongo_c)
 
-    with pytest.raises(monty_op_err) as monty_err:
+    with pytest.raises(monty_op_err):
         monty_c = monty_sort(docs, sort)
         next(monty_c)
 

--- a/tests/test_engine/test_update/test_update.py
+++ b/tests/test_engine/test_update/test_update.py
@@ -12,10 +12,10 @@ def test_update_err_1(monty_update, mongo_update):
     ]
     spec = {"$inc": {"a.b": 1}, "$min": {"a.b": 1}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -46,10 +46,10 @@ def test_update_positional_filtered_err_2(monty_update, mongo_update):
     spec = {"$inc": {"a.$[elem].b": 1}}
     array_filters = [{"elem.b": {"$gt": 4}}, {"elem.c": {"$gt": 4}}]
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec, array_filters=array_filters)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec, array_filters=array_filters)
 
     # ignore comparing error code
@@ -64,10 +64,10 @@ def test_update_positional_filtered_err_3(monty_update, mongo_update):
     spec = {"$inc": {"a.$[elem].b": 1}}
     array_filters = [{"elem.b": {"$gt": 4}}, {"other": {"$gt": 4}}]
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec, array_filters=array_filters)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec, array_filters=array_filters)
 
     # ignore comparing error code
@@ -82,10 +82,10 @@ def test_update_positional_filtered_err_4(monty_update, mongo_update):
     spec = {"$inc": {"a.$[elem].b": 1}}
     array_filters = [{"elem.b": {"$gt": 4}}, {"notuse": {"$gt": 4}}]
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec, array_filters=array_filters)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec, array_filters=array_filters)
 
     # ignore comparing error code
@@ -102,10 +102,10 @@ def test_update_positional_filtered_err_5(monty_update, mongo_update):
                      {"notuse": {"$gt": 4}},
                      {"notuse2": {"$gt": 4}}]
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec, array_filters=array_filters)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec, array_filters=array_filters)
 
     # ignore comparing error code
@@ -120,10 +120,10 @@ def test_update_positional_filtered_err_6(monty_update, mongo_update):
     spec = {"$inc": {"a.$[elem.b].c": 1}}
     array_filters = [{"elem.b.d": {"$gt": 0}}]
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec, array_filters=array_filters)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec, array_filters=array_filters)
 
     # ignore comparing error code
@@ -138,10 +138,10 @@ def test_update_positional_filtered_err_7(monty_update, mongo_update):
     spec = {"$inc": {"a.$[elem].b.c": 1}}
     array_filters = []
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec, array_filters=array_filters)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec, array_filters=array_filters)
 
     # ignore comparing error code
@@ -190,10 +190,10 @@ def test_update_positional_filtered_has_conflict_1(monty_update, mongo_update):
     array_filters = [{"elem.c": {"$gt": 0}},  # update element 0
                      {"conflict": {"b": 4, "c": 1}}]  # update element 0, too.
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec, array_filters=array_filters)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec, array_filters=array_filters)
 
     # ignore comparing error code
@@ -208,10 +208,10 @@ def test_update_positional_filtered_has_conflict_2(monty_update, mongo_update):
     array_filters = [{"elem.c": 5},  # update element 0
                      {"conflict.b": 1}]  # update element 0, too.
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec, array_filters=array_filters)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec, array_filters=array_filters)
 
     # ignore comparing error code
@@ -383,10 +383,10 @@ def test_update_positional_without_query_condition(monty_update, mongo_update):
     spec = {"$inc": {"a.$.b": 1}}
     find = {}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec, find)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec, find)
 
     # ignore comparing error code
@@ -415,10 +415,10 @@ def test_update_array_faild_1(monty_update, mongo_update):
     ]
     spec = {"$inc": {"a.1.$[]": 1}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -431,10 +431,10 @@ def test_update_array_faild_2(monty_update, mongo_update):
     ]
     spec = {"$inc": {"a.1.$[]": 1}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -447,10 +447,10 @@ def test_update_array_faild_3(monty_update, mongo_update):
     ]
     spec = {"$inc": {"a.1.$[]": 1}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -463,10 +463,10 @@ def test_update_with_dollar_prefixed_field_1(monty_update, mongo_update):
     ]
     spec = {"$inc": {"a.$a": 1}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -479,10 +479,10 @@ def test_update_with_dollar_prefixed_field_2(monty_update, mongo_update):
     ]
     spec = {"$set": {"b": {"$ey": [5]}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -495,10 +495,10 @@ def test_update_with_dollar_prefixed_field_3(monty_update, mongo_update):
     ]
     spec = {"$set": {"a": {"b": [{"$a": 5}]}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -573,10 +573,10 @@ def test_update_complex_position_3(monty_update, mongo_update):
     spec = {"$inc": {"a.$[].$[]": 10}}
     find = {"a.b.1": {"$gt": 5}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec, find)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec, find)
 
     # ignore comparing error code
@@ -603,10 +603,10 @@ def test_update_with_bad_spec(monty_update, mongo_update):
     ]
     spec = {"$inc": 5}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -619,10 +619,10 @@ def test_update_rename_conflict_1(monty_update, mongo_update):
     ]
     spec = {"$set": {"c.d": {}}, "$rename": {"a.b": "c.d.b"}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -635,10 +635,10 @@ def test_update_rename_conflict_2(monty_update, mongo_update):
     ]
     spec = {"$rename": {"a.b": "c.b.f", "d.e": "c.b"}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -651,10 +651,10 @@ def test_update_with_empty_field_1(monty_update, mongo_update):
     ]
     spec = {"$inc": {"": 5}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -667,10 +667,10 @@ def test_update_with_empty_field_2(monty_update, mongo_update):
     ]
     spec = {"$inc": {".": 5}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code

--- a/tests/test_engine/test_update/test_update_addToSet.py
+++ b/tests/test_engine/test_update/test_update_addToSet.py
@@ -53,10 +53,10 @@ def test_update_addToSet_4(monty_update, mongo_update):
     ]
     spec = {"$addToSet": {"a": 3}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code

--- a/tests/test_engine/test_update/test_update_currentDate.py
+++ b/tests/test_engine/test_update/test_update_currentDate.py
@@ -78,10 +78,10 @@ def test_update_currentDate_5(monty_update, mongo_update):
     ]
     spec = {"$currentDate": {"a": 1}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -94,10 +94,10 @@ def test_update_currentDate_6(monty_update, mongo_update):
     ]
     spec = {"$currentDate": {"a": {"not_op": True}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -110,10 +110,10 @@ def test_update_currentDate_7(monty_update, mongo_update):
     ]
     spec = {"$currentDate": {"a": {"$type": "not date nor timestamp"}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code

--- a/tests/test_engine/test_update/test_update_inc.py
+++ b/tests/test_engine/test_update/test_update_inc.py
@@ -28,10 +28,10 @@ def test_update_inc_2(monty_update, mongo_update):
     ]
     spec = {"$inc": {"a": 1}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -44,10 +44,10 @@ def test_update_inc_3(monty_update, mongo_update):
     ]
     spec = {"$inc": {"a": "1"}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -102,10 +102,10 @@ def test_update_inc_7(monty_update, mongo_update):
     ]
     spec = {"$inc": {"a.b": 1}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code
@@ -279,10 +279,10 @@ def test_update_inc_null(monty_update, mongo_update):
     ]
     spec = {"$inc": {"a": 1}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code
@@ -295,10 +295,10 @@ def test_update_inc_bool(monty_update, mongo_update):
     ]
     spec = {"$inc": {"a": 1}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code

--- a/tests/test_engine/test_update/test_update_mod_each.py
+++ b/tests/test_engine/test_update/test_update_mod_each.py
@@ -38,10 +38,10 @@ def test_update_mod_each_3(monty_update, mongo_update):
     ]
     spec = {"$push": {"a": {"$set": [5], "$each": [20, 30, 10]}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -54,10 +54,10 @@ def test_update_mod_each_4(monty_update, mongo_update):
     ]
     spec = {"$addToSet": {"a": {"$each": [5], "$sort": 1}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -70,10 +70,10 @@ def test_update_mod_each_5(monty_update, mongo_update):
     ]
     spec = {"$addToSet": {"a": {"$sort": 1, "$each": [5]}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -86,10 +86,10 @@ def test_update_mod_each_6(monty_update, mongo_update):
     ]
     spec = {"$addToSet": {"a": {"$each": None}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -102,10 +102,10 @@ def test_update_mod_each_7(monty_update, mongo_update):
     ]
     spec = {"$push": {"a": {"$each": None}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code

--- a/tests/test_engine/test_update/test_update_mod_position.py
+++ b/tests/test_engine/test_update/test_update_mod_position.py
@@ -52,10 +52,10 @@ def test_update_mod_position_4(monty_update, mongo_update):
     ]
     spec = {"$addToSet": {"a": {"$each": [70, 30, 80], "$position": 2}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -68,10 +68,10 @@ def test_update_mod_position_5(monty_update, mongo_update):
     ]
     spec = {"$push": {"a": {"$each": [70, 80], "$position": True}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code

--- a/tests/test_engine/test_update/test_update_mod_slice.py
+++ b/tests/test_engine/test_update/test_update_mod_slice.py
@@ -81,10 +81,10 @@ def test_update_mod_slice_6(monty_update, mongo_update):
     ]
     spec = {"$push": {"a": {"$each": [], "$slice": True}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code

--- a/tests/test_engine/test_update/test_update_mod_sort.py
+++ b/tests/test_engine/test_update/test_update_mod_sort.py
@@ -72,10 +72,10 @@ def test_update_mod_sort_5(monty_update, mongo_update):
     ]
     spec = {"$push": {"a": {"$each": [], "$sort": []}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -88,10 +88,10 @@ def test_update_mod_sort_6(monty_update, mongo_update):
     ]
     spec = {"$push": {"a": {"$each": [], "$sort": 2}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -124,10 +124,10 @@ def test_update_mod_sort_8(monty_update, mongo_update):
     ]
     spec = {"$push": {"a": {"$each": [], "$sort": {"x": 3, "y": 1}}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -140,10 +140,10 @@ def test_update_mod_sort_9(monty_update, mongo_update):
     ]
     spec = {"$push": {"a": {"$each": [], "$sort": {"x": {"z": 1}, "y": 1}}}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code

--- a/tests/test_engine/test_update/test_update_mul.py
+++ b/tests/test_engine/test_update/test_update_mul.py
@@ -28,10 +28,10 @@ def test_update_mul_2(monty_update, mongo_update):
     ]
     spec = {"$mul": {"a": 2}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -44,10 +44,10 @@ def test_update_mul_3(monty_update, mongo_update):
     ]
     spec = {"$mul": {"a": "2"}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         monty_update(docs, spec)
 
     # ignore comparing error code
@@ -102,10 +102,10 @@ def test_update_mul_7(monty_update, mongo_update):
     ]
     spec = {"$mul": {"a.b": 2}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code
@@ -279,10 +279,10 @@ def test_update_mul_null(monty_update, mongo_update):
     ]
     spec = {"$mul": {"a": 2}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code
@@ -295,10 +295,10 @@ def test_update_mul_bool(monty_update, mongo_update):
     ]
     spec = {"$mul": {"a": 2}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code

--- a/tests/test_engine/test_update/test_update_pop.py
+++ b/tests/test_engine/test_update/test_update_pop.py
@@ -37,10 +37,10 @@ def test_update_pop_3(monty_update, mongo_update):
     docs = []
     spec = {"$pop": {"a": 3}}  # Expected an integer
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code
@@ -53,10 +53,10 @@ def test_update_pop_4(monty_update, mongo_update):
     # Cannot represent as a 64-bit integer
     spec = {"$pop": {"a": Decimal128("1.1")}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code
@@ -67,10 +67,10 @@ def test_update_pop_5(monty_update, mongo_update):
     docs = []
     spec = {"$pop": {"a": "not num"}}  # Expected a number
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code
@@ -83,10 +83,10 @@ def test_update_pop_6(monty_update, mongo_update):
     ]
     spec = {"$pop": {"a.b": 1}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code
@@ -99,10 +99,10 @@ def test_update_pop_7(monty_update, mongo_update):
     ]
     spec = {"$pop": {"a": True}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code

--- a/tests/test_engine/test_update/test_update_pull.py
+++ b/tests/test_engine/test_update/test_update_pull.py
@@ -25,10 +25,10 @@ def test_update_pull_2(monty_update, mongo_update):
     ]
     spec = {"$pull": {"a": 3}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code

--- a/tests/test_engine/test_update/test_update_pullAll.py
+++ b/tests/test_engine/test_update/test_update_pullAll.py
@@ -28,10 +28,10 @@ def test_update_pullAll_2(monty_update, mongo_update):
     ]
     spec = {"$pullAll": {"a": [1]}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code
@@ -44,10 +44,10 @@ def test_update_pullAll_3(monty_update, mongo_update):
     ]
     spec = {"$pullAll": {"a": 1}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code

--- a/tests/test_engine/test_update/test_update_push.py
+++ b/tests/test_engine/test_update/test_update_push.py
@@ -25,10 +25,10 @@ def test_update_push_2(monty_update, mongo_update):
     ]
     spec = {"$push": {"a": 3}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code

--- a/tests/test_engine/test_update/test_update_rename.py
+++ b/tests/test_engine/test_update/test_update_rename.py
@@ -53,10 +53,10 @@ def test_update_rename_4(monty_update, mongo_update):
     ]
     spec = {"$rename": {"a.b": "a"}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code
@@ -69,10 +69,10 @@ def test_update_rename_5(monty_update, mongo_update):
     ]
     spec = {"$rename": {"a.1.b": "b"}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code
@@ -85,10 +85,10 @@ def test_update_rename_6(monty_update, mongo_update):
     ]
     spec = {"$rename": {"a.b": 5}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code
@@ -101,10 +101,10 @@ def test_update_rename_7(monty_update, mongo_update):
     ]
     spec = {"$rename": {"a.b": "c.0"}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code
@@ -117,10 +117,10 @@ def test_update_rename_8(monty_update, mongo_update):
     ]
     spec = {"$rename": {"a": "a"}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code
@@ -161,10 +161,10 @@ def test_update_rename_11(monty_update, mongo_update):
     ]
     spec = {"$rename": {"a.0.b": "a"}}
 
-    with pytest.raises(mongo_write_err) as mongo_err:
+    with pytest.raises(mongo_write_err):
         mongo_update(docs, spec)
 
-    with pytest.raises(monty_write_err) as monty_err:
+    with pytest.raises(monty_write_err):
         next(monty_update(docs, spec))
 
     # ignore comparing error code

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -114,8 +114,8 @@ def test_utils_montyexport(monty_client, tmp_monty_utils_repo):
                 loaded_exported.append(json_util.loads(d))
                 loaded_examples.append(json_util.loads(s))
 
-        def sort(l):
-            return sorted(l, key=lambda i: i["_id"])
+        def sort(lst):
+            return sorted(lst, key=lambda i: i["_id"])
 
         for d, s in zip(sort(loaded_exported), sort(loaded_examples)):
             assert d == s


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/ambiguous-variable-name

https://docs.astral.sh/ruff/rules/unused-variable

Also possible:
```diff
-  with pytest.raises(mongo_dup_key_err) as mongo_err:
+  with pytest.raises(mongo_dup_key_err) as _mongo_err:
```