### PR TITLE
Add Python 3.14 to the testing

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
         experimental: [ false ]
         monty-storage: [ memory, flatfile, sqlite ]
         mongodb-version: [ "3.6", "4.0", "4.2" ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12", "3.13" , "3.14" , "3.14t", "3.15" , "3.15t" ]
 
     steps:
     - uses: actions/checkout@v6
@@ -38,6 +38,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
 
     - name: Install dependencies
       run: uv sync

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Most of the CRUD operators have been implemented. You can visit [issue #14](http
 This project is tested against:
 
 - MongoDB: 3.6, 4.0, 4.2 (4.4 on the way💦)
-- Python: 3.7, 3.8, 3.9, 3.10, 3.11, 3.12
+- Python: >= 3.7
 
 
 ## Install
@@ -88,7 +88,7 @@ set_storage(
     
     repository="/db/repo",  # dir path for database to live on disk, default is {cwd}
     storage="flatfile",     # storage name, default "flatfile"
-    mongo_version="4.0",    # try matching behavior with this mongodb version
+    mongo_version="4.2",    # try matching behavior with this mongodb version
     use_bson=False,         # default None, and will import pymongo's bson if None or True
 
     # any other kwargs are storage engine settings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Database",
   "Topic :: Database :: Database Engines/Servers",
 ]


### PR DESCRIPTION
Related to #124
* #124 

---
* https://docs.python.org/3/whatsnew/3.14.html
* https://docs.python.org/3.15/whatsnew/3.15.html
* https://py-free-threading.github.io/testing

% `git grep threading`
```
montydb/types/objectid.py:import threading
montydb/types/objectid.py:    _inc_lock = threading.Lock()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded GitHub Actions test matrix to include Python 3.14, 3.14t, 3.15, and 3.15t with prerelease version support enabled.
  * Updated package metadata to advertise Python 3.13 and 3.14 support.

* **Documentation**
  * Updated supported Python versions documentation from 3.7–3.12 to Python >= 3.7.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/davidlatwe/montydb/pull/125)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->