### PR TITLE
chore(lint): remove default ruff lint configuration from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,6 @@ dev = [
   "toml",
 ]
 
-[tool.ruff]
-line-length = 88
-exclude = [ ".venv", "venv" ]
-
 [tool.ruff.lint]
 extend-select = [
   "UP",


### PR DESCRIPTION
## Description

Remove default ruff lint configuration from **pyproject.toml**

See: 
[ruff-default-line-length](https://docs.astral.sh/ruff/settings/#line-length)
[ruff-default-exclude](https://docs.astral.sh/ruff/settings/#exclude)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified linting configuration for improved consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/davidlatwe/montydb/pull/127)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->